### PR TITLE
shunting-yard-rs-fork

### DIFF
--- a/demo.rs
+++ b/demo.rs
@@ -218,7 +218,14 @@ fn eval<T: Deref<Target=Token>>(data: &str, postfix: &[T]) -> f32
                 stack.push(result);
             },
 
-            (None, Some(b)) => return b,
+            (None, Some(b)) => {
+		let result = if matches!(tok.token_type, Lexer::Minus) {
+		    -b
+		} else {
+		    b
+		};
+		stack.push(result)
+	    }
             (None, None) | (Some(_), None) => unreachable!()
         }
     }

--- a/demo.rs
+++ b/demo.rs
@@ -219,7 +219,7 @@ fn eval<T: Deref<Target=Token>>(data: &str, postfix: &[T]) -> f32
             },
 
             (None, Some(b)) => {
-		let result = if matches!(tok.token_type, Lexer::Minus) {
+		let result = if let Lexer::Minus = tok.token_type {
 		    -b
 		} else {
 		    b


### PR DESCRIPTION
Previous implementation assumes '-' is always a binary operator but that assumption is broken for expressions like '-19+20'. This change fixes that by adding 0 as the left operand if '-' only has one (right) operand to work with.

Tested: expressions such as '-19' and '1+(-19+2*20)' now works correctly (but weren't before).
